### PR TITLE
remove_lodash_foreach

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,6 @@
  * Module Dependencies
  */
 var fastdom = require('fastdom');
-var each    = require("lodash.foreach");
-
 
 // uid for jobs
 var uid = 0;
@@ -21,8 +19,8 @@ var uid = 0;
  * constructor
  */
 function Fastdom(_fastdom) {
-	// Mainly used for testing.
-	this._fastdom = _fastdom || fastdom;
+  // Mainly used for testing.
+  this._fastdom = _fastdom || fastdom;
   this._jobs = {
     read: {},
     write: {},
@@ -108,13 +106,17 @@ Fastdom.prototype.defer = function(frames, fn, ctx) {
  */
 Fastdom.prototype.clear = function() {
   var self = this;
-  var clear = function(id) {
-    self._fastdom.clear(id);
+  var clearItems = function(queue) {
+    for (var key in queue) {
+      if (queue.hasOwnProperty(key)) {
+        self._fastdom.clear(queue[key]);
+      }
+    }
   };
 
-  each(this._jobs.read,  clear);
-  each(this._jobs.write, clear);
-  each(this._jobs.defer, clear);
+  clearItems(this._jobs.read);
+  clearItems(this._jobs.write);
+  clearItems(this._jobs.defer);
 
   // Clear the queues
   this._jobs.read  = {};

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "url": "https://github.com/orangemug/instantiable-fastdom/issues"
   },
   "dependencies": {
-    "fastdom": "^0.8.4",
-    "lodash.foreach": "^2.4.1"
+    "fastdom": "^0.8.4"
   },
   "devDependencies": {
     "mocha": "~1.18.2",

--- a/test/index.js
+++ b/test/index.js
@@ -1,23 +1,11 @@
 var assert = require("assert");
 var sinon  = require("sinon");
+var size   = require("lodash.size");
 
 var fastdom = require("fastdom");
 var raf     = require("./raf");
 var Fastdom = require("../");
 
-function size(obj) {
-  if (Object.keys) {
-    return Object.keys(obj).length;
-  } else {
-    var result = [];
-    for (prop in obj) {
-      if (obj.hasOwnProperty(prop)) {
-        result.push(prop);
-      }
-    }
-    return result.length;
-  }
-}
 
 describe("instantiable-fastdom", function() {
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,23 @@
 var assert = require("assert");
 var sinon  = require("sinon");
-var size   = require("lodash.size");
 
 var fastdom = require("fastdom");
 var raf     = require("./raf");
 var Fastdom = require("../");
 
+function size(obj) {
+  if (Object.keys) {
+    return Object.keys(obj).length;
+  } else {
+    var result = [];
+    for (prop in obj) {
+      if (obj.hasOwnProperty(prop)) {
+        result.push(prop);
+      }
+    }
+    return result.length;
+  }
+}
 
 describe("instantiable-fastdom", function() {
 


### PR DESCRIPTION
The use of lodash forEach is bringing in approximately 1100 lines of dependent code. Since here it was being used for simple iteration with no context injection it can be easily replaced with a for..in loop with no performance degradation (in fact probably runs a little faster FWIW)
